### PR TITLE
Allow running ci and sonarcloud pipeline from github gui

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: 'CI: Build, Test and Format'
 on:
   pull_request:
     types: [ opened, reopened, synchronize ]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   sonarcloud:


### PR DESCRIPTION
Allow running ci and sonarcloud pipeline from github gui